### PR TITLE
Improve filtered data rendering performance

### DIFF
--- a/modules/extensions/src/data-filter/shader-module.ts
+++ b/modules/extensions/src/data-filter/shader-module.ts
@@ -146,6 +146,12 @@ const inject = {
     #endif
   `,
 
+  'vs:#main-end': `
+    if (dataFilter_value == 0.0) {
+      gl_Position = vec4(-2, -2, -2, 1);
+    }
+  `,
+
   'vs:DECKGL_FILTER_SIZE': `
     if (filter_transformSize) {
       size = size * dataFilter_value;


### PR DESCRIPTION
Moves filtered geometry off-screen to avoid excessive and needless fragment costs.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #7509
<!-- For other PRs without open issue -->
#### Background
Poor performance for a common use case in our application lead to a slight change in the data-filter extension - resulting in the frame rate jumping from 3-4 FPS to 120 FPS.
<!-- For all the PRs -->
#### Change List
- Tweak the data-filter extension's shader to move the geometry outside of clip space resulting in significantly reduced fragment costs.
